### PR TITLE
allow overriding TV's own name through homebridge config

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@
    >       "platform": "PanasonicVieraTV",
    >       "tvs": [
    >          {
+   >            "tvName": "YOUR_TV_NAME_HERE",
    >            "ipAddress": "YOUR_TV_IP_ADDRESS_HERE",
    >            "hdmiInputs": [
    >              {
@@ -107,9 +108,11 @@
      >
      > "tvs": [
      >   {
+     >     "tvName": "YOUR_TV_NAME_HERE",
      >     "ipAddress": "YOUR_TV_IP_ADDRESS_HERE",
      >     "hdmiInputs": []
      >   }, {
+     >     "tvName": "YOUR_TV_NAME_HERE",
      >     "ipAddress": "YOUR_SECOND_TV_IP_ADDRESS_HERE",
      >     "hdmiInputs": []
      >   }
@@ -129,6 +132,28 @@
 7. [re]start homebridge
 
 ## tips and tricks
+
+### TV Naming
+
+If you'd prefer for Vieramatic to automatically detect the name on your TV, then you can remove the "tvName" field from your config.
+
+Your config.json file will look like this:
+
+   > ```JSON
+   > "tvs": [
+   >   {
+   >     "tvName": "YOUR_TV_NAME_HERE",
+   >     "ipAddress": "YOUR_TV_IP_ADDRESS_HERE",
+   >     "hdmiInputs": [
+   >       {
+   >         "id" : "1",
+   >         "name": "Apple TV"
+   >       }, {
+   >         "id" : "2",
+   >         "name": "VodafoneTV box"
+   >       }
+   > ]
+   > ```
 
 ### supported TV sets
 

--- a/README.md
+++ b/README.md
@@ -133,9 +133,9 @@
 
 ## tips and tricks
 
-### TV Naming
+### TV naming
 
-If you'd prefer for Vieramatic to automatically detect the name on your TV, then you can remove the "tvName" field from your config.
+If you'd prefer for Vieramatic to automatically detect and consume the name on your TV, then you can remove the "tvName" field from your config.
 
 Your config.json file will look like this:
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@
    >       "platform": "PanasonicVieraTV",
    >       "tvs": [
    >          {
-   >            "tvName": "YOUR_TV_NAME_HERE",
+   >            "friendlyName": "YOUR_TV_NAME_HERE",
    >            "ipAddress": "YOUR_TV_IP_ADDRESS_HERE",
    >            "hdmiInputs": [
    >              {
@@ -108,11 +108,11 @@
      >
      > "tvs": [
      >   {
-     >     "tvName": "YOUR_TV_NAME_HERE",
+     >     "friendlyName": "YOUR_TV_NAME_HERE",
      >     "ipAddress": "YOUR_TV_IP_ADDRESS_HERE",
      >     "hdmiInputs": []
      >   }, {
-     >     "tvName": "YOUR_TV_NAME_HERE",
+     >     "friendlyName": "YOUR_TV_NAME_HERE",
      >     "ipAddress": "YOUR_SECOND_TV_IP_ADDRESS_HERE",
      >     "hdmiInputs": []
      >   }
@@ -142,7 +142,7 @@ Your config.json file will look like this:
    > ```JSON
    > "tvs": [
    >   {
-   >     "tvName": "YOUR_TV_NAME_HERE",
+   >     "friendlyName": "YOUR_TV_NAME_HERE",
    >     "ipAddress": "YOUR_TV_IP_ADDRESS_HERE",
    >     "hdmiInputs": [
    >       {

--- a/config.schema.json
+++ b/config.schema.json
@@ -12,7 +12,7 @@
       "items": {
         "type": "object",
         "properties": {
-          "tvName": {
+          "friendlyName": {
             "title": "TV Name",
             "description": "The name you'd like to set for the TV. If unset, the name set on the TV will be used.",
             "type": "string",
@@ -75,7 +75,7 @@
       "flex-flow": "row wrap",
       "key": "tvs",
       "items": [
-        "tvs[].tvName",
+        "tvs[].friendlyName",
         "tvs[].ipAddress",
         {
           "key": "tvs[]",

--- a/config.schema.json
+++ b/config.schema.json
@@ -14,7 +14,7 @@
         "properties": {
           "tvName": {
             "title": "TV Name",
-            "description": "The name you'd like to set for the TV.",
+            "description": "The name you'd like to set for the TV. If unset, the name set on the TV will be used.",
             "type": "string",
             "required": false
           },
@@ -59,7 +59,6 @@
               }
             }
           },
-
           "customVolumeSlider": {
             "title": "Volume control service",
             "description": "Whether to enable a fan as an additional TV volume control artifact to HomeKit",
@@ -97,12 +96,14 @@
         {
           "key": "tvs[].hdmiInputs",
           "type": "tabarray",
-
           "items": [
             {
               "type": "flex",
               "flex-flow": "row",
-              "items": ["tvs[].hdmiInputs[].id", "tvs[].hdmiInputs[].name"]
+              "items": [
+                "tvs[].hdmiInputs[].id",
+                "tvs[].hdmiInputs[].name"
+              ]
             }
           ]
         },

--- a/config.schema.json
+++ b/config.schema.json
@@ -12,6 +12,12 @@
       "items": {
         "type": "object",
         "properties": {
+          "tvName": {
+            "title": "TV Name",
+            "description": "The name you'd like to set for the TV.",
+            "type": "string",
+            "required": false
+          },
           "ipAddress": {
             "title": "IP address",
             "description": "The IP address of your TV.",
@@ -70,6 +76,7 @@
       "flex-flow": "row wrap",
       "key": "tvs",
       "items": [
+        "tvs[].tvName",
         "tvs[].ipAddress",
         {
           "key": "tvs[]",

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -18,7 +18,7 @@ const displayName = (string: string): string => {
 };
 
 export interface UserConfig {
-  tvName?: string;
+  friendlyName?: string;
   ipAddress: string;
   encKey?: string;
   appId?: string;
@@ -105,21 +105,20 @@ export class VieramaticPlatformAccessory {
       );
 
     this.accessory.on('identify', () => {
-      this.log.info(accessory.displayName, 'Identify!!!');
+      this.log.info(device.specs.friendlyName, 'Identify!!!');
     });
 
     this.service = this.accessory.addService(this.Service.Television);
 
     this.service.setCharacteristic(
       this.Characteristic.Name,
-      // device.specs.friendlyName <- Not too sure what the difference is between Name and ConfiguredName
-      accessory.displayName
+      device.specs.friendlyName
     );
 
     this.service
       .setCharacteristic(
         this.Characteristic.ConfiguredName,
-        accessory.displayName
+        device.specs.friendlyName
       )
       .setCharacteristic(
         this.Characteristic.SleepDiscoveryMode,
@@ -158,7 +157,7 @@ export class VieramaticPlatformAccessory {
 
     const speakerService = this.accessory.addService(
       this.Service.TelevisionSpeaker,
-      `${accessory.displayName} Volume`,
+      `${device.specs.friendlyName} Volume`,
       'volumeService'
     );
 
@@ -185,7 +184,7 @@ export class VieramaticPlatformAccessory {
     if (this.userConfig.customVolumeSlider === true) {
       const customSpeakerService = this.accessory.addService(
         this.Service.Fan,
-        `${accessory.displayName} Volume`,
+        `${device.specs.friendlyName} Volume`,
         'VolumeAsFanService'
       );
       this.service.addLinkedService(customSpeakerService);
@@ -229,7 +228,7 @@ export class VieramaticPlatformAccessory {
     if (!this.storage.data) {
       this.log.info(
         'Initializing',
-        accessory.displayName,
+        device.specs.friendlyName,
         'for the first time. [II]'
       );
       this.storage.data = {
@@ -253,7 +252,7 @@ export class VieramaticPlatformAccessory {
         }
       );
     } else {
-      this.log.debug('Restoring', accessory.displayName);
+      this.log.debug('Restoring', device.specs.friendlyName);
       // check for new user added inputs
       userConfig.hdmiInputs.forEach((input) => {
         const fn = function isThere(element): boolean {

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -18,6 +18,7 @@ const displayName = (string: string): string => {
 };
 
 export interface UserConfig {
+  tvName?: string;
   ipAddress: string;
   encKey?: string;
   appId?: string;
@@ -202,7 +203,7 @@ export class VieramaticPlatformAccessory {
           (value: CharacteristicValue, callback: CharacteristicSetCallback) => {
             this.log.debug('(customSpeakerService/On.set)', value);
             switch (
-              this.service.getCharacteristic(this.Characteristic.Active).value
+            this.service.getCharacteristic(this.Characteristic.Active).value
             ) {
               case this.Characteristic.Active.INACTIVE:
                 return callback(undefined, false);

--- a/src/accessory.ts
+++ b/src/accessory.ts
@@ -112,13 +112,14 @@ export class VieramaticPlatformAccessory {
 
     this.service.setCharacteristic(
       this.Characteristic.Name,
-      device.specs.friendlyName
+      // device.specs.friendlyName <- Not too sure what the difference is between Name and ConfiguredName
+      accessory.displayName
     );
 
     this.service
       .setCharacteristic(
         this.Characteristic.ConfiguredName,
-        device.specs.friendlyName
+        accessory.displayName
       )
       .setCharacteristic(
         this.Characteristic.SleepDiscoveryMode,
@@ -157,7 +158,7 @@ export class VieramaticPlatformAccessory {
 
     const speakerService = this.accessory.addService(
       this.Service.TelevisionSpeaker,
-      `${device.specs.friendlyName} Volume`,
+      `${accessory.displayName} Volume`,
       'volumeService'
     );
 
@@ -184,7 +185,7 @@ export class VieramaticPlatformAccessory {
     if (this.userConfig.customVolumeSlider === true) {
       const customSpeakerService = this.accessory.addService(
         this.Service.Fan,
-        `${device.specs.modelNumber} Volume`,
+        `${accessory.displayName} Volume`,
         'VolumeAsFanService'
       );
       this.service.addLinkedService(customSpeakerService);
@@ -228,7 +229,7 @@ export class VieramaticPlatformAccessory {
     if (!this.storage.data) {
       this.log.info(
         'Initializing',
-        device.specs.friendlyName,
+        accessory.displayName,
         'for the first time. [II]'
       );
       this.storage.data = {
@@ -252,7 +253,7 @@ export class VieramaticPlatformAccessory {
         }
       );
     } else {
-      this.log.debug('Restoring', device.specs.friendlyName);
+      this.log.debug('Restoring', accessory.displayName);
       // check for new user added inputs
       userConfig.hdmiInputs.forEach((input) => {
         const fn = function isThere(element): boolean {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -117,9 +117,10 @@ export class VieramaticPlatform implements DynamicPlatformPlugin {
         return;
       }
     }
+    const tvName = (device.tvName ?? tv.specs.friendlyName)
     /* eslint-disable-next-line new-cap */
     const accessory = new this.api.platformAccessory<Record<string, VieraTV>>(
-      tv.specs.friendlyName,
+      tvName,
       tv.specs.serialNumber
     );
     accessory.category = this.api.hap.Categories.TELEVISION;
@@ -131,14 +132,14 @@ export class VieramaticPlatform implements DynamicPlatformPlugin {
     ) {
       this.log.info(
         'Initializing',
-        tv.specs.friendlyName,
+        tvName,
         'for the first time. [I]'
       );
       const status = await tv.isTurnedOn();
       if (status !== true) {
         this.log.error(
           'Unable to finish initial setup of',
-          tv.specs.friendlyName,
+          tvName,
           '. Please make sure that this TV is powered ON and NOT in stand-by.'
         );
         return;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -117,10 +117,12 @@ export class VieramaticPlatform implements DynamicPlatformPlugin {
         return;
       }
     }
-    const tvName = (device.tvName ?? tv.specs.friendlyName)
+    if (device.friendlyName) {
+      tv.specs.friendlyName = device.friendlyName;
+    }
     /* eslint-disable-next-line new-cap */
     const accessory = new this.api.platformAccessory<Record<string, VieraTV>>(
-      tvName,
+      tv.specs.friendlyName,
       tv.specs.serialNumber
     );
     accessory.category = this.api.hap.Categories.TELEVISION;
@@ -132,14 +134,14 @@ export class VieramaticPlatform implements DynamicPlatformPlugin {
     ) {
       this.log.info(
         'Initializing',
-        tvName,
+        tv.specs.friendlyName,
         'for the first time. [I]'
       );
       const status = await tv.isTurnedOn();
       if (status !== true) {
         this.log.error(
           'Unable to finish initial setup of',
-          tvName,
+          tv.specs.friendlyName,
           '. Please make sure that this TV is powered ON and NOT in stand-by.'
         );
         return;

--- a/src/viera.ts
+++ b/src/viera.ts
@@ -684,8 +684,7 @@ export class VieraTV implements VieraTV {
               } else {
                 /* eslint-disable prettier/prettier */
                 body = `
-                Found a <b>${specs.modelNumber
-}</b>, on ip address ${ip}, which requires encryption.
+                Found a <b>${specs.modelNumber}</b>, on ip address ${ip}, which requires encryption.
                 <br />
                 <form action="/">
                   <label for="pin">


### PR DESCRIPTION
As requested by issue #38 by [@Marfre888](https://github.com/Marfre888), I have implemented his first request. As @AntonioMeireles stated, this was fairly trivial and required very few lines of code, as well as updating log lines to contain the new input.

I have tested compatibility with 2.0.11-beta.2 and renamed TV on one device and confirmed it works without any issues and changes across devices.

@AntonioMeireles, please suggest any further improvements you would like to see before merging.